### PR TITLE
Publish plugin from master builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ publish: bin/porter$(FILE_EXT)
 	fi
 
 	# Generate the plugin feed
-	#az storage blob download -c porter -n plugins/atom.xml -f bin/plugins/atom.xml
-	bin/porter plugins feed generate -d bin/plugins -f bin/plugins/atom.xml -t build/atom-template.xml
-	#az storage blob upload -c porter -n plugins/atom.xml -f bin/atom.xml
+	az storage blob download -c porter -n plugins/atom.xml -f bin/plugins/atom.xml
+	bin/porter mixins feed generate -d bin/plugins -f bin/plugins/atom.xml -t build/atom-template.xml
+	az storage blob upload -c porter -n plugins/atom.xml -f bin/plugins/atom.xml
 
 bin/porter$(FILE_EXT):
 	curl -fsSLo bin/porter$(FILE_EXT) https://cdn.porter.sh/canary/porter-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)

--- a/build/atom-template.xml
+++ b/build/atom-template.xml
@@ -7,18 +7,18 @@
         <name>Porter Authors</name>
         <uri>https://porter.sh</uri>
     </author>
-    {{#Plugins}}
+    {{#Mixins}}
     <category term="{{.}}"/>
-    {{/Plugins}}
+    {{/Mixins}}
     {{#Entries}}
     <entry>
-        <id>https://cdn.porter.sh/plugins/{{Plugin}}/{{Version}}</id>
-        <title>{{Plugin}} @ {{Version}}</title>
+        <id>https://cdn.porter.sh/plugins/{{Mixin}}/{{Version}}</id>
+        <title>{{Mixin}} @ {{Version}}</title>
         <updated>{{Updated}}</updated>
-        <category term="{{Plugin}}"/>
+        <category term="{{Mixin}}"/>
         <content>{{Version}}</content>
         {{#Files}}
-        <link rel="download" href="https://cdn.porter.sh/plugins/{{Plugin}}/{{Version}}/{{File}}" />
+        <link rel="download" href="https://cdn.porter.sh/plugins/{{Mixin}}/{{Version}}/{{File}}" />
         {{/Files}}
     </entry>
     {{/Entries}}

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -44,9 +44,9 @@ steps:
   workingDirectory: '$(modulePath)'
   displayName: 'Cross Compile'
 
-#- script: |
-#    export AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING)
-#    make publish
-#  workingDirectory: '$(modulePath)'
-#  displayName: 'Publish'
-#  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+- script: |
+    export AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING)
+    make publish
+  workingDirectory: '$(modulePath)'
+  displayName: 'Publish'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))


### PR DESCRIPTION
Reusing `porter mixin feed generate` for now, later we can make a command specific to plugins