### PR TITLE
Safe write tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.5.1
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	google.golang.org/genproto v0.0.0-20191007204434-a023cd5227bd // indirect
 	google.golang.org/grpc v1.24.0 // indirect
 )

--- a/pkg/azure/blob/migration.go
+++ b/pkg/azure/blob/migration.go
@@ -3,8 +3,8 @@ package blob
 import (
 	"context"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 // Add tags to each claim so that when the migration runs,
@@ -12,29 +12,27 @@ import (
 // type = claims
 
 func (s *Store) migrateToTaggedClaims() error {
+	s.logger.Warn("Tagging claims data in preparation for claims migration")
+
 	// List all claims
 	blobs, err := s.listBlobs("claims/")
 	if err != nil {
-		return errors.Wrap(err, "unable to list claims for migration to the new azure plugin storage format")
+		return errors.Wrap(err, "Unable to list claims for migration to the new azure plugin storage format")
 	}
 
-	container, err := s.buildContainerURL()
-	if err != nil {
-		return err
+	tags := map[string]string{
+		"type": "claims",
 	}
 
-	var bigErr *multierror.Error
+	g := new(errgroup.Group)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for _, blob := range blobs {
-		tags := map[string]string{
-			"type": "claims",
-		}
-
-		blobURL := container.NewBlobURL(blob.Name)
-		_, err = blobURL.SetTags(context.Background(), tags)
-		if err != nil {
-			err = multierror.Append(bigErr, err)
-		}
+		g.Go(func() error {
+			return s.setTag(ctx, blob.Name, tags)
+		})
 	}
 
-	return bigErr.ErrorOrNil()
+	return g.Wait()
 }

--- a/pkg/azure/blob/store.go
+++ b/pkg/azure/blob/store.go
@@ -284,7 +284,7 @@ func (s *Store) setTag(ctx context.Context, blobName string, tags map[string]str
 	return g.Wait()
 }
 
-// waitForMigratedTagCacheWarm waits until a query for the specified tags returns at least the
+// waitForTagInCache waits until a query for the specified tags returns at least the
 // specified number of blobs, indicating that the tag cache has caught up with the tags applied
 // during the migration. Not sure why this is necessary, but it seems to avoid a race condition
 // and nothing ends up being migrated.

--- a/pkg/azure/blob/store.go
+++ b/pkg/azure/blob/store.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strings"
 	"text/template"
+	"time"
 
 	"get.porter.sh/plugin/azure/pkg/azure/azureconfig"
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -16,6 +17,7 @@ import (
 	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/hashicorp/go-hclog"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 var _ crud.Store = &Store{}
@@ -80,7 +82,6 @@ func (s *Store) List(itemType string, group string) ([]string, error) {
 		return nil, err
 	}
 
-	s.logger.Info("matching blobs:")
 	names := make([]string, 0, len(items))
 	for _, blobInfo := range items {
 		// Return just the name portion of the blob, e.g. installations/INSTALLATION -> INSTALLATION
@@ -88,7 +89,7 @@ func (s *Store) List(itemType string, group string) ([]string, error) {
 		names = append(names, fileName)
 	}
 
-	s.logger.Info(strings.Join(names, ", "))
+	s.logger.Info(fmt.Sprintf("blob names: %s", strings.Join(names, ", ")))
 	return names, nil
 }
 
@@ -127,6 +128,8 @@ func (s *Store) filterBlobsByTags(tags map[string]string) ([]azblob.BlobItem, er
 		s.logger.Error(errors.Wrapf(err, "error filtering blobs where %s", opts.Where).Error())
 		return nil, err
 	}
+
+	s.logger.Info(fmt.Sprintf("matched %d blobs", len(result.Segment.BlobItems)))
 	return result.Segment.BlobItems, nil
 }
 
@@ -174,8 +177,8 @@ func (s *Store) saveBlob(path string, tags map[string]string, data []byte) error
 		return err
 	}
 
-	if tags != nil {
-		_, err = blob.SetTags(context.Background(), tags)
+	if tags != nil && len(tags) > 0 {
+		err = s.setTag(context.Background(), path, tags)
 	}
 
 	return err
@@ -253,6 +256,57 @@ func (s *Store) getBlob(itemType string, blobName string) ([]byte, error) {
 	_, err = buff.ReadFrom(bodyStream)
 
 	return buff.Bytes(), err
+}
+
+// setTag on a blob and wait for the tag index to sync.
+func (s *Store) setTag(ctx context.Context, blobName string, tags map[string]string) error {
+	g := new(errgroup.Group)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	container, err := s.buildContainerURL()
+	if err != nil {
+		return err
+	}
+
+	blobURL := container.NewBlobURL(blobName)
+
+	s.logger.Info(fmt.Sprintf("Setting tags on %s: %v", blobName, tags))
+	g.Go(func() error {
+		_, err = blobURL.SetTags(ctx, tags)
+		return err
+	})
+
+	g.Go(func() error {
+		return s.waitForTagInCache(ctx, blobName, tags)
+	})
+
+	return g.Wait()
+}
+
+// waitForMigratedTagCacheWarm waits until a query for the specified tags returns at least the
+// specified number of blobs, indicating that the tag cache has caught up with the tags applied
+// during the migration. Not sure why this is necessary, but it seems to avoid a race condition
+// and nothing ends up being migrated.
+func (s *Store) waitForTagInCache(parentCtx context.Context, blobName string, tags map[string]string) error {
+	ctx, cancel := context.WithTimeout(parentCtx, 30*time.Second)
+	defer cancel()
+	s.logger.Info("Waiting for tags to sync...")
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.New("Timed out waiting for the azure blob storage tags cache to warm up")
+		default:
+			cachedBlobs, _ := s.filterBlobsByTags(tags)
+			for _, b := range cachedBlobs {
+				if b.Name == blobName {
+					s.logger.Info(fmt.Sprintf("Found %s, tag cache warm", blobName))
+					return nil
+				}
+				time.Sleep(time.Second)
+			}
+		}
+	}
 }
 
 func (s *Store) buildServiceURL() (azblob.ServiceURL, error) {


### PR DESCRIPTION
Ensure that the tag is readable before returning. This works around a problem where there is an unknown delay after setting a tag on a blob before you can query for the blob by the tag. When we return immediately, this causes bugs because Porter expects to be able to query for the data immediately using the crud.Store interface which relies on the tags.

So after setting a tag on a blob, query for it in a loop until we get the blob back, then allow the call to return.